### PR TITLE
Fix typo on Exhibits

### DIFF
--- a/app/views/shared/_essays_and_exibits.html.haml
+++ b/app/views/shared/_essays_and_exibits.html.haml
@@ -1,5 +1,5 @@
 %a.dropdown-toggle{href: "#", role: "button", "data-toggle" => "dropdown", "aria-haspopup"=>"true", "aria-expanded"=>"false"}
-  Essays & Exibits
+  Essays & Exhibits
   %span.caret
 %ul.dropdown-menu
   %li.dropdown.dropdown-submenu


### PR DESCRIPTION
Menu label spelled as Exibit - needs the h!